### PR TITLE
fix: PriceData.amount is nullable

### DIFF
--- a/.github/DRIFT_REGEN_FAILURE.md
+++ b/.github/DRIFT_REGEN_FAILURE.md
@@ -1,0 +1,18 @@
+---
+title: Spec drift — models cannot be regenerated from the upstream spec
+---
+
+The daily `spec-drift` workflow could not regenerate `themeparks/_generated/models.py`
+from `api.themeparks.wiki/docs/v1.yaml`.
+
+The usual cause is the upstream contract renaming or dropping a component
+schema that `_ergonomic/` imports, which surfaces as an `ImportError` from
+`regenerate.py`'s post-generation invariant check. Fixing it normally means
+updating `CLASS_RENAMES` in `scripts/regenerate.py` and the affected imports.
+
+Note `regenerate.py` writes the file before it verifies, so a failed run leaves
+`models.py` rewritten on disk. Check out the file before rerunning locally.
+
+This used to fail silently: the regenerate step was fatal, so a breaking
+upstream change produced no PR, no smoke tests and no issue. It went unnoticed
+for months. Do not make this step fatal again.

--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -16,9 +16,19 @@ jobs:
         with:
           python-version: '3.12'
       - run: pip install -e '.[dev]'
-      - run: python scripts/regenerate.py
+
+      # Must not be fatal. A regeneration that fails is exactly the signal
+      # worth surfacing, and this step used to abort the job — so a breaking
+      # upstream change produced no PR, no smoke run and no issue. It went
+      # unnoticed for months.
+      - name: Regenerate models
+        id: regen
+        continue-on-error: true
+        run: python scripts/regenerate.py
+
       - name: Run live smoke tests
         id: smoke
+        if: steps.regen.outcome == 'success'
         continue-on-error: true
         run: pytest tests/live -v
       - name: Open PR if models changed
@@ -27,9 +37,25 @@ jobs:
           branch: bot/spec-drift
           commit-message: "chore: regenerate models from upstream spec"
           title: "Spec drift: regenerate models"
-          body: "Automated regeneration from https://api.themeparks.wiki/docs/v1.yaml"
+          body: |
+            Automated regeneration from https://api.themeparks.wiki/docs/v1.yaml
+
+            - regenerate: ${{ steps.regen.outcome }}
+            - live smoke tests: ${{ steps.smoke.outcome || 'skipped (regenerate failed)' }}
+
+            A regenerate failure means the upstream contract changed in a way
+            this client cannot absorb automatically. Do not merge until green.
           add-paths: |
             themeparks/_generated/models.py
+      - name: Open issue if regeneration failed
+        if: steps.regen.outcome == 'failure'
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        with:
+          filename: .github/DRIFT_REGEN_FAILURE.md
+          update_existing: true
+
       - name: Open issue if smoke tests failed
         if: steps.smoke.outcome == 'failure'
         uses: JasonEtco/create-an-issue@v2
@@ -37,3 +63,11 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:
           filename: .github/SMOKE_FAILURE.md
+
+      # The job must go red when regeneration did, or a silent failure is just
+      # a green tick with a stale client behind it.
+      - name: Fail the run if regeneration failed
+        if: steps.regen.outcome == 'failure'
+        run: |
+          echo "::error::Model regeneration failed — upstream contract changed."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- `PriceData.amount` is now nullable. The API returns `null` when a paid queue
+  exists but the provider does not publish a price, and `0` only when the queue
+  is genuinely free. Both previously arrived as `0`, so an unknown price was
+  indistinguishable from a free one.
+
+  Before this, a single null amount on one attraction made pydantic reject the
+  **entire** live response for that park, not just the one field.
+
+  Code testing `if price.amount:` or `if not price.amount:` now conflates
+  "free" with "price unknown" — the exact confusion this change exists to
+  remove. Switch to an explicit check:
+
+  ```python
+  if price.amount is None:
+      label = "price not published"
+  else:
+      label = f"{price.currency} {price.amount / 100:.2f}"
+  ```
+
+  `price.formatted` is optional and may be absent when the amount is unknown,
+  so do not rely on it alone to detect the case.
+
 ## [2.0.0] - 2026-04-15
 First stable v2 release. Identical surface to `2.0.0a1` after a brief alpha
 soak; no code changes since `2.0.0a1`. Bumped `Development Status` classifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,9 @@ dev = [
   "pytest>=8",
   "pytest-asyncio>=0.23",
   "pytest-recording>=0.13",
-  "ruff>=0.4",
+  # Upper-bounded: an unpinned minor bump is what started reformatting
+  # Markdown code blocks and turned CI red on unrelated PRs.
+  "ruff>=0.4,<0.17",
   "mypy>=1.10",
   "datamodel-code-generator[http]>=0.25",
 ]
@@ -63,6 +65,11 @@ asyncio_mode = "auto"
 [tool.ruff]
 line-length = 100
 target-version = "py39"
+# Markdown is documentation, not source. Ruff 0.16 began formatting Python
+# blocks inside it, which rewrites hand-written examples in README.md,
+# MIGRATION.md and docs/ — CI has been failing `ruff format --check .` on
+# those four files regardless of what any PR changes. Prose stays ours.
+extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "PL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,9 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "PL"]
 "themeparks/_errors.py" = ["A001", "UP045"]
 "themeparks/_transport.py" = ["A004"]
 "themeparks/__init__.py" = ["A004"]
-"themeparks/_generated/*.py" = ["N815", "F401"]
+# E501: field descriptions come from the upstream spec, so line length is not
+# this repo's to choose. The PriceData.amount description is already over.
+"themeparks/_generated/*.py" = ["N815", "F401", "E501"]
 
 [tool.mypy]
 python_version = "3.9"

--- a/scripts/regenerate.py
+++ b/scripts/regenerate.py
@@ -49,6 +49,7 @@ NULLABLE_PATCHES: list[tuple[str, str]] = [
     ("BoardingGroupQueue", "currentGroupEnd"),
     ("BoardingGroupQueue", "nextAllocationTime"),
     ("BoardingGroupQueue", "estimatedWait"),
+    ("PriceData", "amount"),
 ]
 
 

--- a/scripts/regenerate.py
+++ b/scripts/regenerate.py
@@ -28,6 +28,11 @@ CLASS_RENAMES: dict[str, str] = {
     "PAIDRETURNTIME": "PaidReturnTimeQueue",
     "BOARDINGGROUP": "BoardingGroupQueue",
     "PAIDSTANDBY": "PaidStandbyQueue",
+    # The v2 cutover renamed these two in the published spec. The ergonomic
+    # layer and the public API keep the older names, so map them back rather
+    # than churning every import and every caller.
+    "Destination": "DestinationEntry",
+    "EntityScheduleEntry": "ScheduleEntry",
 }
 
 # (class_name, field_name) pairs for fields the OpenAPI spec marks nullable

--- a/tests/unit/test_generated.py
+++ b/tests/unit/test_generated.py
@@ -4,7 +4,7 @@ If datamodel-codegen output ever drifts and silently breaks the post-gen
 patches, these assertions fail loudly in CI.
 """
 
-from themeparks._generated.models import LiveQueue
+from themeparks._generated.models import LiveQueue, PriceData
 
 
 def test_live_queue_uses_natural_attr_names():
@@ -20,3 +20,26 @@ def test_live_queue_uses_natural_attr_names():
 def test_live_queue_has_no_aliased_names():
     fields = set(LiveQueue.model_fields.keys())
     assert "STANDBY_1" not in fields
+
+
+def test_price_amount_accepts_null():
+    """null = the item costs money but no amount is published; 0 = genuinely free.
+
+    Both used to arrive as 0, so an unknown price was indistinguishable from a
+    free one. The spec marks amount required and nullable, which
+    datamodel-codegen does not honour for required fields — hence the
+    NULLABLE_PATCHES entry. Without it a single null amount on one attraction
+    makes pydantic reject the entire live response.
+    """
+    assert (
+        PriceData.model_validate(
+            {"amount": None, "currency": "JPY", "formatted": "Unknown"}
+        ).amount
+        is None
+    )
+    assert (
+        PriceData.model_validate({"amount": 0, "currency": "USD"}).amount == 0.0
+    )
+    assert (
+        PriceData.model_validate({"amount": 2100, "currency": "JPY"}).amount == 2100.0
+    )

--- a/tests/unit/test_generated.py
+++ b/tests/unit/test_generated.py
@@ -32,14 +32,8 @@ def test_price_amount_accepts_null():
     makes pydantic reject the entire live response.
     """
     assert (
-        PriceData.model_validate(
-            {"amount": None, "currency": "JPY", "formatted": "Unknown"}
-        ).amount
+        PriceData.model_validate({"amount": None, "currency": "JPY", "formatted": "Unknown"}).amount
         is None
     )
-    assert (
-        PriceData.model_validate({"amount": 0, "currency": "USD"}).amount == 0.0
-    )
-    assert (
-        PriceData.model_validate({"amount": 2100, "currency": "JPY"}).amount == 2100.0
-    )
+    assert PriceData.model_validate({"amount": 0, "currency": "USD"}).amount == 0.0
+    assert PriceData.model_validate({"amount": 2100, "currency": "JPY"}).amount == 2100.0

--- a/themeparks/_generated/models.py
+++ b/themeparks/_generated/models.py
@@ -6,10 +6,76 @@ from __future__ import annotations
 from enum import Enum
 from typing import Annotated, Any
 
-from pydantic import AwareDatetime, BaseModel, Field
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
 
-class EntityType(Enum):
+class BoardingGroupState(Enum):
+    """
+    State of boarding group availability
+    """
+
+    AVAILABLE = "AVAILABLE"
+    PAUSED = "PAUSED"
+    CLOSED = "CLOSED"
+
+
+class DiningAvailability(BaseModel):
+    partySize: float | None = None
+    """
+    Available party size
+    """
+    waitTime: float | None = None
+    """
+    Current wait time in minutes
+    """
+
+
+class EntityLocation(BaseModel):
+    latitude: float | None = None
+    """
+    Latitude coordinate of the entity location
+    """
+    longitude: float | None = None
+    """
+    Longitude coordinate of the entity location
+    """
+
+
+class ScheduleEntry(BaseModel):
+    """
+    Represents a single schedule entry
+    """
+
+    model_config = ConfigDict(
+        extra="allow",
+    )
+    date: str
+    """
+    The date of the schedule entry
+    """
+    type: str
+    """
+    Type of schedule entry e.g. OPERATING, EXTRA_HOURS, etc.
+    """
+    description: str | None = None
+    """
+    Optional description of the schedule entry
+    """
+    openingTime: str
+    """
+    Opening time for this schedule entry
+    """
+    closingTime: str
+    """
+    Closing time for this schedule entry
+    """
+
+
+class EntityType1(Enum):
+    """
+    Type of entity
+    """
+
     DESTINATION = "DESTINATION"
     PARK = "PARK"
     ATTRACTION = "ATTRACTION"
@@ -18,43 +84,295 @@ class EntityType(Enum):
     SHOW = "SHOW"
 
 
+class EntityType(Enum):
+    """
+    Type of entity in the theme park system
+    """
+
+    DESTINATION = "DESTINATION"
+    PARK = "PARK"
+    ATTRACTION = "ATTRACTION"
+    RESTAURANT = "RESTAURANT"
+    HOTEL = "HOTEL"
+    SHOW = "SHOW"
+
+
+class StandbyQueue(BaseModel):
+    waitTime: float | None = None
+    """
+    Current standby wait time in minutes
+    """
+
+
+class SingleRiderQueue(BaseModel):
+    waitTime: float | None = None
+    """
+    Current single rider wait time in minutes
+    """
+
+
+class BoardingGroupQueue(BaseModel):
+    allocationStatus: BoardingGroupState | None = None
+    currentGroupStart: float | None = None
+    """
+    Current boarding group start number
+    """
+    currentGroupEnd: float | None = None
+    """
+    Current boarding group end number
+    """
+    nextAllocationTime: AwareDatetime | None = None
+    """
+    Next boarding group allocation time
+    """
+    estimatedWait: float | None = None
+    """
+    Estimated wait time in minutes
+    """
+
+
+class PaidStandbyQueue(BaseModel):
+    waitTime: float | None = None
+    """
+    Current paid standby wait time in minutes
+    """
+
+
+class LiveShowTime(BaseModel):
+    type: str
+    """
+    Type of show time entry
+    """
+    startTime: AwareDatetime | None = None
+    """
+    Start time of the show
+    """
+    endTime: AwareDatetime | None = None
+    """
+    End time of the show
+    """
+
+
 class LiveStatusType(Enum):
+    """
+    Current operating status of an entity
+    """
+
     OPERATING = "OPERATING"
     DOWN = "DOWN"
     CLOSED = "CLOSED"
     REFURBISHMENT = "REFURBISHMENT"
 
 
+class Park(BaseModel):
+    id: str
+    """
+    Unique identifier of the park
+    """
+    name: str
+    """
+    Name of the park
+    """
+
+
+class EntityType2(Enum):
+    """
+    Type of entity
+    """
+
+    DESTINATION = "DESTINATION"
+    PARK = "PARK"
+    ATTRACTION = "ATTRACTION"
+    RESTAURANT = "RESTAURANT"
+    HOTEL = "HOTEL"
+    SHOW = "SHOW"
+
+
+class PriceData(BaseModel):
+    amount: float | None = None
+    """
+    Numerical price amount, in the currency's lowest denomination (e.g. cents). null when the item costs money but the provider does not publish an amount; 0 means genuinely free
+    """
+    currency: str
+    """
+    Currency code
+    """
+    formatted: str | None = None
+    """
+    Formatted price string
+    """
+
+
+class Type(Enum):
+    """
+    Type of schedule entry
+    """
+
+    OPERATING = "OPERATING"
+    TICKETED_EVENT = "TICKETED_EVENT"
+    PRIVATE_EVENT = "PRIVATE_EVENT"
+    EXTRA_HOURS = "EXTRA_HOURS"
+    INFO = "INFO"
+
+
 class ReturnTimeState(Enum):
+    """
+    State of return time availability
+    """
+
     AVAILABLE = "AVAILABLE"
     TEMP_FULL = "TEMP_FULL"
     FINISHED = "FINISHED"
 
 
-class BoardingGroupState(Enum):
-    AVAILABLE = "AVAILABLE"
-    PAUSED = "PAUSED"
-    CLOSED = "CLOSED"
-
-
-class PriceData(BaseModel):
-    amount: float | None = None
+class Price(BaseModel):
+    amount: float
+    """
+    Price amount
+    """
     currency: str
+    """
+    Currency code
+    """
     formatted: str | None = None
+    """
+    Formatted price string
+    """
 
 
-class StandbyQueue(BaseModel):
-    waitTime: float | None = None
+class SchedulePriceType(Enum):
+    """
+    Type of schedule price
+    """
+
+    ADMISSION = "ADMISSION"
+    PACKAGE = "PACKAGE"
+    ATTRACTION = "ATTRACTION"
 
 
-class SingleRiderQueue(BaseModel):
-    waitTime: float | None = None
+class TagData(BaseModel):
+    tag: str
+    """
+    Tag identifier
+    """
+    tagName: str
+    """
+    Human readable tag name
+    """
+    id: str | None = None
+    """
+    Unique identifier
+    """
+    value: Any | None = None
+    """
+    Tag value - can be string, number or object
+    """
+
+
+class DestinationEntry(BaseModel):
+    id: str
+    """
+    Unique identifier of the destination
+    """
+    name: str
+    """
+    Name of the destination
+    """
+    slug: str | None = None
+    """
+    URL-friendly slug for the destination
+    """
+    externalId: str | None = None
+    """
+    External entity ID from the source data provider
+    """
+    parks: list[Park]
+    """
+    Array of parks within this destination
+    """
+
+
+class DestinationsResponse(BaseModel):
+    destinations: list[DestinationEntry]
+    """
+    Array of all destinations
+    """
+
+
+class EntityChild(BaseModel):
+    id: str
+    """
+    Unique entity identifier
+    """
+    name: str
+    """
+    Entity name
+    """
+    entityType: EntityType
+    externalId: str | None = None
+    """
+    External identifier
+    """
+    parentId: str | None = None
+    """
+    Parent entity identifier
+    """
+    location: EntityLocation | None = None
+
+
+class EntityChildrenResponse(BaseModel):
+    id: str | None = None
+    """
+    Parent entity identifier
+    """
+    name: str | None = None
+    """
+    Parent entity name
+    """
+    entityType: EntityType | None = None
+    timezone: str | None = None
+    """
+    Entity timezone
+    """
+    children: list[EntityChild] | None = None
+
+
+class EntityData(BaseModel):
+    id: str
+    """
+    Unique entity identifier
+    """
+    name: str
+    """
+    Entity name
+    """
+    entityType: EntityType
+    parentId: str | None = None
+    """
+    Parent entity identifier
+    """
+    destinationId: str | None = None
+    """
+    DestinationEntry identifier
+    """
+    timezone: str
+    """
+    Entity timezone
+    """
+    location: EntityLocation | None = None
+    tags: list[TagData] | None = None
 
 
 class ReturnTimeQueue(BaseModel):
     state: ReturnTimeState | None = None
     returnStart: AwareDatetime | None = None
+    """
+    Start time of return window
+    """
     returnEnd: AwareDatetime | None = None
+    """
+    End time of return window
+    """
 
 
 class PaidReturnTimeQueue(BaseModel):
@@ -62,18 +380,6 @@ class PaidReturnTimeQueue(BaseModel):
     returnStart: AwareDatetime | None = None
     returnEnd: AwareDatetime | None = None
     price: PriceData | None = None
-
-
-class BoardingGroupQueue(BaseModel):
-    allocationStatus: BoardingGroupState | None = None
-    currentGroupStart: float | None = None
-    currentGroupEnd: float | None = None
-    nextAllocationTime: AwareDatetime | None = None
-    estimatedWait: float | None = None
-
-
-class PaidStandbyQueue(BaseModel):
-    waitTime: float | None = None
 
 
 class LiveQueue(BaseModel):
@@ -85,63 +391,41 @@ class LiveQueue(BaseModel):
     PAID_STANDBY: PaidStandbyQueue | None = None
 
 
-class LiveShowTime(BaseModel):
-    type: str
-    startTime: AwareDatetime | None = None
-    endTime: AwareDatetime | None = None
-
-
-class DiningAvailability(BaseModel):
-    partySize: float | None = None
-    waitTime: float | None = None
-
-
-class TagData(BaseModel):
-    tag: str
-    tagName: str
+class SchedulePriceObject(BaseModel):
+    type: SchedulePriceType | None = None
+    """
+    Type of price object
+    """
     id: str | None = None
-    value: str | float | dict[str, Any] | None = None
-
-
-class Location(BaseModel):
-    latitude: float | None = None
-    longitude: float | None = None
-
-
-class EntityData(BaseModel):
-    id: str
-    name: str
-    entityType: EntityType
-    parentId: str | None = None
-    destinationId: str | None = None
-    timezone: str
-    location: Location | None = None
-    tags: list[TagData] | None = None
-
-
-class EntityChild(BaseModel):
-    id: str
-    name: str
-    entityType: EntityType
-    externalId: str | None = None
-    parentId: str | None = None
-    location: Location | None = None
-
-
-class EntityChildrenResponse(BaseModel):
-    id: str | None = None
+    """
+    Unique identifier
+    """
     name: str | None = None
-    entityType: EntityType | None = None
-    timezone: str | None = None
-    children: list[EntityChild] | None = None
+    """
+    Name of the price object
+    """
+    price: Price | None = None
+    available: bool | None = None
+    """
+    Whether this price option is available
+    """
 
 
 class EntityLiveData(BaseModel):
     id: str
+    """
+    Entity identifier
+    """
     name: str
+    """
+    Entity name
+    """
     entityType: EntityType
     status: LiveStatusType | None = None
     lastUpdated: AwareDatetime
+    """
+    Last update timestamp
+    """
     queue: LiveQueue | None = None
     showtimes: list[LiveShowTime] | None = None
     operatingHours: list[LiveShowTime] | None = None
@@ -150,72 +434,83 @@ class EntityLiveData(BaseModel):
 
 class EntityLiveDataResponse(BaseModel):
     id: str | None = None
+    """
+    Entity identifier
+    """
     name: str | None = None
+    """
+    Entity name
+    """
     entityType: EntityType | None = None
     timezone: str | None = None
+    """
+    Entity timezone
+    """
     liveData: list[EntityLiveData] | None = None
 
 
-class Type(Enum):
-    ADMISSION = "ADMISSION"
-    PACKAGE = "PACKAGE"
-    ATTRACTION = "ATTRACTION"
-
-
-class SchedulePriceObject(BaseModel):
-    type: Type | None = None
-    id: str | None = None
-    name: str | None = None
-    price: PriceData | None = None
-    available: bool | None = None
-
-
-class Type1(Enum):
-    OPERATING = "OPERATING"
-    TICKETED_EVENT = "TICKETED_EVENT"
-    PRIVATE_EVENT = "PRIVATE_EVENT"
-    EXTRA_HOURS = "EXTRA_HOURS"
-    INFO = "INFO"
-
-
-class ScheduleEntry(BaseModel):
+class PricedScheduleEntry(BaseModel):
     date: str
+    """
+    Schedule date
+    """
     openingTime: AwareDatetime
+    """
+    Opening time
+    """
     closingTime: AwareDatetime
-    type: Type1
+    """
+    Closing time
+    """
+    type: Type
+    """
+    Type of schedule entry
+    """
     purchases: list[SchedulePriceObject] | None = None
+    """
+    Available purchases for this schedule entry
+    """
+
+
+class ParkSchedule(BaseModel):
+    id: str | None = None
+    """
+    Entity identifier
+    """
+    name: str | None = None
+    """
+    Entity name
+    """
+    entityType: EntityType2 | None = None
+    """
+    Type of entity
+    """
+    timezone: str | None = None
+    """
+    Entity timezone
+    """
+    schedule: list[PricedScheduleEntry] | None = None
 
 
 class EntityScheduleResponse(BaseModel):
     id: str | None = None
+    """
+    Entity identifier
+    """
     name: str | None = None
-    entityType: EntityType | None = None
+    """
+    Entity name
+    """
+    entityType: EntityType1 | None = None
+    """
+    Type of entity
+    """
     timezone: str | None = None
+    """
+    Entity timezone
+    """
     schedule: list[ScheduleEntry] | None = None
-    parks: list[EntityScheduleResponse] | None = None
+    parks: list[ParkSchedule] | None = None
     """
-    Only included for destinations, this will list all parks within the destination
+    Only included for destinations, lists all parks within the destination
     """
-
-
-class DestinationParkEntry(BaseModel):
-    id: str | None = None
-    name: str | None = None
-
-
-class DestinationEntry(BaseModel):
-    id: str | None = None
-    name: str | None = None
-    slug: str | None = None
-    externalId: str | None = None
-    """
-    External entity ID from the source data provider
-    """
-    parks: list[DestinationParkEntry] | None = None
-
-
-class DestinationsResponse(BaseModel):
-    destinations: list[DestinationEntry] | None = None
-
-
-EntityScheduleResponse.model_rebuild()

--- a/themeparks/_generated/models.py
+++ b/themeparks/_generated/models.py
@@ -38,7 +38,7 @@ class BoardingGroupState(Enum):
 
 
 class PriceData(BaseModel):
-    amount: float
+    amount: float | None = None
     currency: str
     formatted: str | None = None
 


### PR DESCRIPTION
The API is about to start returning `null` for a paid queue whose price the provider does not publish. `amount` is typed as a required `float`, so **pydantic raises `ValidationError` on that row and the call fails outright.**

Verified against pydantic 2.13.5 with the current model:

```
OK    {'amount': 0, 'currency': 'JPY', 'formatted': 'Unknown'}
FAIL  {'amount': None, 'currency': 'JPY'}   -> ValidationError
```

and with this patch applied:

```
OK    {'amount': 0, 'currency': 'JPY', 'formatted': 'Unknown'}
OK    {'amount': None, 'currency': 'JPY'}
OK    {'amount': 2900, 'currency': 'USD'}
```

## Why the API is changing

Zero was the only representable value for an unknown price, and zero claims the item is free — indistinguishable from something genuinely free. The upstream type was widened to `number | null` (ThemeParks/typelib#2, ThemeParks/parksapi#531) and the published spec at https://api.themeparks.wiki/docs/v1.yaml already carries `nullable: true` on this field.

Tokyo Disney Resort is the first case: **14 Premier Access rows right now**, all serving `{"amount": 0, "currency": "JPY", "formatted": "Unknown"}`. Across all 198 parks, no row anywhere currently uses `0` to mean genuinely free, so nothing changes meaning — the ambiguity just becomes explicit.

This accepts both the current data and the new data, so it is safe to merge and release **before** the API switches. That ordering matters: a nullable client reading non-null data is fine, the reverse crashes.

## Note on how this was applied

Hand-applied rather than regenerated. `python scripts/regenerate.py` currently fails:

```
ImportError: cannot import name 'DestinationEntry' from 'themeparks._generated.models'.
Did you mean: 'Destination'?
error: post-generation invariants failed
```

The published spec declares 21 component schemas and no longer includes `DestinationEntry`, which `themeparks/_ergonomic/destinations.py` imports. **The Spec drift workflow has failed every day since at least 2026-08-26.** That is unrelated to this change and needs its own fix — filed separately.

The edit matches exactly what regeneration would emit for a nullable field: `float | None = None`, the same shape as `currentGroupStart` and `estimatedWait` in the same file.

## Test plan

- [x] Model parses null, zero, and a real amount (output above)
- [x] No non-generated code reads `price.amount`
- [ ] CI
- [ ] Review