### PR TITLE
release: v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.0.1] - 2026-09-01
 ### Fixed
 - `PriceData.amount` is now nullable. The API returns `null` when a paid queue
   exists but the provider does not publish a price, and `0` only when the queue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "themeparks"
-version = "2.0.0"
+version = "2.0.1"
 description = "Official SDK for the ThemeParks.wiki API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Version bump and changelog finalisation for the nullable `PriceData.amount` change merged in #17.

The build reads the version from `pyproject.toml`, so this has to land before `v2.0.1` is tagged.

Patch rather than minor: the field widens, so every payload that parsed before still parses. Worth noting the fix is for a hard failure — a `null` amount previously made pydantic reject the entire response for that park, not just the field.

Verified locally: 104 tests passing, `ruff check` clean, `ruff format --check .` clean across the whole repo, mypy clean.