### PR TITLE
fix(docs): point the models page at the models that still exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,16 @@ jobs:
       - run: ruff format --check .
       - run: mypy themeparks
       - run: pytest tests/unit
+
+  # The Docs workflow only runs on push to main, so until this job existed a
+  # PR that renamed a model merged green and broke the docs deploy afterwards.
+  # Building the site here means the same PR fails before it lands.
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+      - run: pip install -e '.[docs]'
+      - run: mkdocs build --strict

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -95,7 +95,7 @@ for the full set.
     options:
       heading_level: 3
 
-::: themeparks._generated.models.DestinationParkEntry
+::: themeparks._generated.models.Park
     options:
       heading_level: 3
 
@@ -105,7 +105,7 @@ for the full set.
 
 ## Shared
 
-::: themeparks._generated.models.Location
+::: themeparks._generated.models.EntityLocation
     options:
       heading_level: 3
 

--- a/tests/unit/test_docs_refs.py
+++ b/tests/unit/test_docs_refs.py
@@ -1,0 +1,65 @@
+"""Every mkdocstrings reference in docs/ must resolve to a real object.
+
+`mkdocs build --strict` already fails on a dangling reference, but it only
+runs on push to main, and it aborts on the first one it meets. So a
+regeneration that renames a model merges green and breaks the docs deploy
+after the fact — which is exactly what `DestinationParkEntry` -> `Park` and
+`Location` -> `EntityLocation` did, for eight consecutive pushes.
+
+This runs in the ordinary unit matrix, costs nothing, and reports every
+broken reference at once instead of one per build.
+"""
+
+import importlib
+import re
+from pathlib import Path
+
+import pytest
+
+DOCS = Path(__file__).resolve().parents[2] / "docs"
+
+# ::: themeparks._generated.models.EntityData
+REFERENCE = re.compile(r"^:::\s+(themeparks[\w.]*)\s*$")
+
+
+def _references() -> list[tuple[str, int, str]]:
+    """(page relative to docs/, line number, dotted target) for every ::: line."""
+    found = []
+    for page in sorted(DOCS.rglob("*.md")):
+        for lineno, line in enumerate(page.read_text().splitlines(), 1):
+            match = REFERENCE.match(line)
+            if match:
+                found.append((str(page.relative_to(DOCS)), lineno, match.group(1)))
+    return found
+
+
+def _resolves(target: str) -> bool:
+    """True if `target` names an importable module or an attribute on one."""
+    try:
+        importlib.import_module(target)
+        return True
+    except ImportError:
+        pass
+
+    module_path, _, attribute = target.rpartition(".")
+    if not module_path:
+        return False
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError:
+        return False
+    return hasattr(module, attribute)
+
+
+def test_docs_directory_is_present():
+    # A wrong DOCS path would make every other test here vacuously pass.
+    assert DOCS.is_dir(), DOCS
+
+
+def test_references_were_found():
+    assert _references(), "no mkdocstrings references found — has docs/ moved?"
+
+
+@pytest.mark.parametrize(("page", "lineno", "target"), _references())
+def test_reference_resolves(page: str, lineno: int, target: str):
+    assert _resolves(target), f"docs/{page}:{lineno} references missing object {target}"


### PR DESCRIPTION
The Docs workflow has failed on every push to `main` since 2026-09-01 — eight
consecutive runs. The published site has not been rebuilt since April.

```
ERROR - mkdocstrings: themeparks._generated.models.DestinationParkEntry could not be found
Aborted with a BuildError!
```

The 2.0.1 regeneration renamed two models and `docs/api/models.md` kept the
old names:

| docs said | model is now |
|---|---|
| `DestinationParkEntry` | `Park` |
| `Location` | `EntityLocation` |

`mkdocs build --strict` aborts on the first reference it cannot collect, so
only the first was ever visible in the log. Neither name was exported from the
package root, so this only affected the docs build, not callers.

## Why it went unnoticed

`docs.yml` runs on push to `main` only. `ci.yml` runs on pull requests but
never builds the site. So a PR that renames a model merges green and breaks
the deploy afterwards, with the failure landing on `main` where nobody is
looking at a check.

## Guards

- `tests/unit/test_docs_refs.py` resolves every `:::` reference in `docs/`
  against the real module. It runs in the existing unit matrix, takes 0.3s,
  and reports every broken reference at once instead of one per build.
- CI builds the site on pull requests, so the same PR fails before it lands.

## Verification

Reverting only the `models.md` change fails the new test on both lines:

```
E  AssertionError: docs/api/models.md:98 references missing object themeparks._generated.models.DestinationParkEntry
E  AssertionError: docs/api/models.md:108 references missing object themeparks._generated.models.Location
2 failed, 44 passed
```

With the fix, the full gate is green locally:

```
ruff check .            All checks passed!
ruff format --check .   33 files already formatted
mypy themeparks         Success: no issues found in 13 source files
pytest tests/unit       150 passed in 0.86s
mkdocs build --strict   Documentation built in 1.27 seconds
```

`Park` and `EntityLocation` render on the built page with their fields
(`Park.id`, `Park.name`, `EntityLocation.latitude`, `EntityLocation.longitude`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)